### PR TITLE
Add stable-fs example

### DIFF
--- a/stable-fs/.gitignore
+++ b/stable-fs/.gitignore
@@ -1,0 +1,25 @@
+# Various IDEs and Editors
+.vscode/
+.idea/
+**/*~
+
+# Mac OSX temporary files
+.DS_Store
+**/.DS_Store
+
+# dfx temporary files
+.dfx/
+
+# generated files
+**/declarations/
+
+# rust
+target/
+
+# frontend code
+node_modules/
+dist/
+.svelte-kit/
+
+# environment variables
+.env

--- a/stable-fs/Cargo.toml
+++ b/stable-fs/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["src/stable-fs-backend"]
+resolver = "2"

--- a/stable-fs/README.md
+++ b/stable-fs/README.md
@@ -1,0 +1,37 @@
+# Basic filesystem example project
+
+This is a simple filesystem example project that can be compiled to the `wasm32-wasip1` target and run in dfx.
+
+It demonstrates how to initialize the `ic_wasi_polyfill` and then use the standard `std::fs` module to read and write files and directories.
+
+It is assumed that you have installed [rust](https://doc.rust-lang.org/book/ch01-01-installation.html) and [dfx](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
+
+
+## Preparation
+
+Install wasi2ic:
+```bash
+  cargo install wasi2ic
+```
+
+## Deployment and testing
+
+Start the `dfx` environment in a separate console:
+```bash
+  dfx start --clean
+```
+
+To build and deploy the canister, run the command:
+```bash
+  dfx deploy
+```
+
+You can now do the canister call:
+```bash
+  dfx canister call stable-fs-backend greet '("test")'
+```
+
+Adter calling the canister, you should see the message:
+
+`("Hello from test.\nThis is a new line of text, should be there in a file.\n")`
+ 

--- a/stable-fs/dfx.json
+++ b/stable-fs/dfx.json
@@ -1,0 +1,19 @@
+{
+  "canisters": {
+    "stable-fs-backend": {
+      "candid": "src/stable-fs-backend/stable-fs-backend.did",
+      "package": "stable-fs-backend",
+      "build": "./scripts/build.sh",
+      "wasm": "target/wasm32-wasip1/release/no_wasi.wasm",
+      "type": "custom"
+    }
+  },
+  "defaults": {
+    "build": {
+      "args": "",
+      "packtool": ""
+    }
+  },
+  "output_env_file": ".env",
+  "version": 1
+}

--- a/stable-fs/scripts/build.sh
+++ b/stable-fs/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+export RELEASE_DIR=./target/wasm32-wasip1/release
+
+pushd $(pwd)
+
+if [ "$(basename "$PWD")" = "scripts" ]; then
+  cd ..
+fi
+
+cargo build --release --target wasm32-wasip1
+
+ic-wasm $RELEASE_DIR/stable_fs_backend.wasm -o $RELEASE_DIR/meta.wasm metadata candid:service -f ./src/stable-fs-backend/stable-fs-backend.did -v public
+
+wasi2ic $RELEASE_DIR/meta.wasm $RELEASE_DIR/no_wasi.wasm
+
+popd

--- a/stable-fs/scripts/test.sh
+++ b/stable-fs/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+#test executing the greet function
+dfx canister call stable-fs-backend greet '("test")'

--- a/stable-fs/src/stable-fs-backend/Cargo.toml
+++ b/stable-fs/src/stable-fs-backend/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 candid = "0.10"
 ic-cdk = "0.17"
 ic-stable-structures = "0.6.7"
-ic-wasi-polyfill = { version = "0.7", features = ["report_wasi_calls"] }
+ic-wasi-polyfill = { version = "0.7" }

--- a/stable-fs/src/stable-fs-backend/Cargo.toml
+++ b/stable-fs/src/stable-fs-backend/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stable-fs-backend"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.10"
+ic-cdk = "0.17"
+ic-stable-structures = "0.6.7"
+ic-wasi-polyfill = { version = "0.7", features = ["report_wasi_calls"] }

--- a/stable-fs/src/stable-fs-backend/src/lib.rs
+++ b/stable-fs/src/stable-fs-backend/src/lib.rs
@@ -22,7 +22,7 @@ fn init_wasi() {
     ic_wasi_polyfill::init_with_memory(&[0u8; 32], &[], wasi_memory);
 }
 
-#[ic_cdk::query]
+#[ic_cdk::update]
 fn greet(name: String) -> String {
     // Create a directory named "data"
     fs::create_dir_all("data").unwrap();

--- a/stable-fs/src/stable-fs-backend/src/lib.rs
+++ b/stable-fs/src/stable-fs-backend/src/lib.rs
@@ -1,11 +1,14 @@
-use std::cell::RefCell;
-
-use ic_stable_structures::memory_manager::MemoryId;
-use ic_stable_structures::{memory_manager::MemoryManager, DefaultMemoryImpl};
-use std::env;
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::Path;
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager},
+    DefaultMemoryImpl,
+};
+use std::{
+    cell::RefCell,
+    env,
+    fs::{self, File},
+    io::Write,
+    path::Path,
+};
 
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =

--- a/stable-fs/src/stable-fs-backend/src/lib.rs
+++ b/stable-fs/src/stable-fs-backend/src/lib.rs
@@ -1,0 +1,63 @@
+use std::cell::RefCell;
+
+use ic_stable_structures::memory_manager::MemoryId;
+use ic_stable_structures::{memory_manager::MemoryManager, DefaultMemoryImpl};
+use std::env;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+thread_local! {
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+}
+
+const WASI_MEMORY_ID: MemoryId = MemoryId::new(0);
+
+fn init_wasi() {
+    let wasi_memory = MEMORY_MANAGER.with(|m| m.borrow().get(WASI_MEMORY_ID));
+    ic_wasi_polyfill::init_with_memory(&[0u8; 32], &[], wasi_memory);
+}
+
+#[ic_cdk::query]
+fn greet(name: String) -> String {
+    // Create a directory named "data"
+    fs::create_dir_all("data").unwrap();
+
+    // Get the current directory
+    let original_dir = env::current_dir().unwrap();
+    println!("Starting directory: {:?}", original_dir);
+
+    // Change to the data directory
+    env::set_current_dir("data").unwrap();
+
+    // Verify we're in the new directory
+    let current_dir = env::current_dir().unwrap();
+    println!("Current directory: {:?}", current_dir);
+
+    // Create and write to a file in the data directory
+    let file_path = Path::new("example.txt");
+    let mut file = File::create(file_path).unwrap();
+
+    // Write some content to the file
+    writeln!(file, "Hello from {}.", name).unwrap();
+    writeln!(
+        file,
+        "This is a new line of text, should be there in a file."
+    )
+    .unwrap();
+
+    file.flush().unwrap();
+
+    fs::read_to_string(file_path).unwrap()
+}
+
+#[ic_cdk::init]
+fn init() {
+    init_wasi();
+}
+
+#[ic_cdk::post_upgrade]
+fn post_upgrade() {
+    init_wasi();
+}

--- a/stable-fs/src/stable-fs-backend/stable-fs-backend.did
+++ b/stable-fs/src/stable-fs-backend/stable-fs-backend.did
@@ -1,0 +1,3 @@
+service : {
+    "greet": (text) -> (text) query;
+}

--- a/stable-fs/src/stable-fs-backend/stable-fs-backend.did
+++ b/stable-fs/src/stable-fs-backend/stable-fs-backend.did
@@ -1,3 +1,3 @@
 service : {
-    "greet": (text) -> (text) query;
+    "greet": (text) -> (text);
 }


### PR DESCRIPTION
# Basic filesystem example project

This is a simple filesystem example project that can be compiled to the `wasm32-wasip1` target and run in dfx.

It demonstrates how to initialize the `ic_wasi_polyfill` and then use the standard `std::fs` module to read and write files and directories.

It is assumed that you have installed [rust](https://doc.rust-lang.org/book/ch01-01-installation.html) and [dfx](https://internetcomputer.org/docs/current/developer-docs/setup/install/).


## Preparation

Install wasi2ic:
```bash
  cargo install wasi2ic
```

## Deployment and testing

Start the `dfx` environment in a separate console:
```bash
  dfx start --clean
```

To build and deploy the canister, run the command:
```bash
  dfx deploy
```

You can now do the canister call:
```bash
  dfx canister call stable-fs-backend greet '("test")'
```

Adter calling the canister, you should see the message:

`("Hello from test.\nThis is a new line of text, should be there in a file.\n")`
 
